### PR TITLE
Update python qlpack.yml to use workspace instead of hardcoded pack.

### DIFF
--- a/python/qlpack.yml
+++ b/python/qlpack.yml
@@ -3,5 +3,5 @@ library: false
 name: advanced-security/codeql-python
 version: 0.2.0
 dependencies:
-  codeql/python-all: "^0.9.2"
+  codeql/python-all: "${workspace}"
 defaultSuiteFile: suites/codeql-python.qls


### PR DESCRIPTION
"To be honest, this shouldn't be a necessary change, but making this change forces codeql to resolve the codeql/python-all pack from source and ignore the conflicting version constraint." - A.E. 2023